### PR TITLE
CORE-286 Update lambda default node runtime

### DIFF
--- a/lambda_express_bundle/api_gateway.tf
+++ b/lambda_express_bundle/api_gateway.tf
@@ -1,8 +1,6 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_iam_role" "lambda_role" {
   name = "${var.config["prefix"]}-AppRole"

--- a/lambda_express_bundle/api_gateway.tf
+++ b/lambda_express_bundle/api_gateway.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {
 }
 
 data "aws_iam_role" "lambda_role" {
-  role_name = "${var.config["prefix"]}-AppRole"
+  name = "${var.config["prefix"]}-AppRole"
 }
 
 # API Gateway

--- a/lambda_express_bundle/variables.tf
+++ b/lambda_express_bundle/variables.tf
@@ -12,7 +12,7 @@ variable "build_command" {
 
 variable "authorization" { default = "NONE" }
 
-variable "lambda_runtime" { default = "nodejs8.10"}
+variable "lambda_runtime" { default = "nodejs10.x"}
 variable "lambda_memory_size" { default = "128" }
 variable "lambda_timeout" { default = "30" }
 variable "lambda_environment_variables" {

--- a/lambda_express_bundle/variables.tf
+++ b/lambda_express_bundle/variables.tf
@@ -12,7 +12,7 @@ variable "build_command" {
 
 variable "authorization" { default = "NONE" }
 
-variable "lambda_runtime" { default = "nodejs6.10"}
+variable "lambda_runtime" { default = "nodejs8.10"}
 variable "lambda_memory_size" { default = "128" }
 variable "lambda_timeout" { default = "30" }
 variable "lambda_environment_variables" {

--- a/lambda_express_bundle_vpc/api_gateway.tf
+++ b/lambda_express_bundle_vpc/api_gateway.tf
@@ -1,11 +1,9 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_iam_role" "lambda_role" {
-  role_name = "${var.config["prefix"]}-AppRole"
+  name = "${var.config["prefix"]}-AppRole"
 }
 
 # API Gateway

--- a/lambda_express_bundle_vpc/variables.tf
+++ b/lambda_express_bundle_vpc/variables.tf
@@ -12,7 +12,7 @@ variable "build_command" {
 
 variable "authorization" { default = "NONE" }
 
-variable "lambda_runtime" { default = "nodejs8.10"}
+variable "lambda_runtime" { default = "nodejs10.x"}
 variable "lambda_memory_size" { default = "128" }
 variable "lambda_timeout" { default = "30" }
 variable "lambda_environment_variables" {

--- a/lambda_express_bundle_vpc/variables.tf
+++ b/lambda_express_bundle_vpc/variables.tf
@@ -12,7 +12,7 @@ variable "build_command" {
 
 variable "authorization" { default = "NONE" }
 
-variable "lambda_runtime" { default = "nodejs6.10"}
+variable "lambda_runtime" { default = "nodejs8.10"}
 variable "lambda_memory_size" { default = "128" }
 variable "lambda_timeout" { default = "30" }
 variable "lambda_environment_variables" {

--- a/lambda_zip_express_bundle/api_gateway.tf
+++ b/lambda_zip_express_bundle/api_gateway.tf
@@ -1,6 +1,6 @@
 data "aws_caller_identity" "current" {}
-data "aws_region" "current" { current = true }
-data "aws_iam_role" "lambda_role" { role_name = "${var.config["prefix"]}-AppRole" }
+data "aws_region" "current" {}
+data "aws_iam_role" "lambda_role" { name = "${var.config["prefix"]}-AppRole" }
 
 # API Gateway
 resource "aws_api_gateway_rest_api" "current" {

--- a/lambda_zip_express_bundle/variables.tf
+++ b/lambda_zip_express_bundle/variables.tf
@@ -7,7 +7,7 @@ variable "lambda_hash" { default = "" }
 
 variable "authorization" { default = "NONE" }
 
-variable "lambda_runtime" { default = "nodejs6.10"}
+variable "lambda_runtime" { default = "nodejs8.10"}
 variable "lambda_memory_size" { default = "128" }
 variable "lambda_timeout" { default = "30" }
 variable "lambda_environment_variables" {

--- a/lambda_zip_express_bundle/variables.tf
+++ b/lambda_zip_express_bundle/variables.tf
@@ -7,7 +7,7 @@ variable "lambda_hash" { default = "" }
 
 variable "authorization" { default = "NONE" }
 
-variable "lambda_runtime" { default = "nodejs8.10"}
+variable "lambda_runtime" { default = "nodejs10.x"}
 variable "lambda_memory_size" { default = "128" }
 variable "lambda_timeout" { default = "30" }
 variable "lambda_environment_variables" {


### PR DESCRIPTION
This will need to correspond with an update to thelighthouse. The aws terraform provider will be updated to 2.11 over in thelighthouse, which does the following:

* deprecates the iam_role.role_name property in favor of iam_role.name
* enables lambda node runtime version `nodejs10.x`