### PR TITLE
CORE-285 Fix Lambda Resource Dependency

### DIFF
--- a/lambda_dotnet/api_gateway.tf
+++ b/lambda_dotnet/api_gateway.tf
@@ -27,7 +27,10 @@ resource "aws_api_gateway_deployment" "current" {
     create_before_destroy = true
   }
 
-  depends_on = ["aws_api_gateway_method.current"]
+  depends_on = [
+    "aws_api_gateway_method.current",
+    "aws_api_gateway_integration.current"
+  ]
 }
 
 data "aws_acm_certificate" "selected" {

--- a/lambda_express_bundle/api_gateway.tf
+++ b/lambda_express_bundle/api_gateway.tf
@@ -29,7 +29,10 @@ resource "aws_api_gateway_deployment" "current" {
     create_before_destroy = true
   }
 
-  depends_on = ["aws_api_gateway_method.current"]
+  depends_on = [
+    "aws_api_gateway_method.current",
+    "aws_api_gateway_integration.current"
+  ]
 }
 
 data "aws_acm_certificate" "selected" {

--- a/lambda_express_bundle_vpc/api_gateway.tf
+++ b/lambda_express_bundle_vpc/api_gateway.tf
@@ -29,7 +29,10 @@ resource "aws_api_gateway_deployment" "current" {
     create_before_destroy = true
   }
 
-  depends_on = ["aws_api_gateway_method.current"]
+  depends_on = [
+    "aws_api_gateway_method.current",
+    "aws_api_gateway_integration.current"
+  ]
 }
 
 data "aws_acm_certificate" "selected" {


### PR DESCRIPTION
Added a dependency on `aws_api_gateway_integration.current` to `aws_api_gateway_deployment`. Now, lambda functions can be setup and torn down in one attempt without failing